### PR TITLE
Updated POM to pull datastax cassandra driver.

### DIFF
--- a/doradus-server/pom.xml
+++ b/doradus-server/pom.xml
@@ -50,5 +50,10 @@
 			<artifactId>cassandra-thrift</artifactId>
 			<version>2.0.7</version>
 		</dependency>
+		<dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+            <version>2.0.3</version>
+        </dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
The classes in the com.dell.doradus.service.db.cql package needed the datastax driver to compile.  Have no idea if this is the correct driver needed.  Also, just noticed that the pom.xml uses TABs instead of spaces.
