### PR TITLE
Modules have version 2.2.0 as parent.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.dell.doradus</groupId>
 	<artifactId>doradus</artifactId>
-	<version>2.1.1</version>
+	<version>2.2.0</version>
 	<packaging>pom</packaging>	
 	
 


### PR DESCRIPTION
The doradus-common, doradus-server and doradus-client modules all refer to this as their parent but are specifying version 2.2.0.  Changed version to 2.2.0 and maven compiles just fine. 
